### PR TITLE
fix(android): fetch termux-app submodule + repair issue log capture

### DIFF
--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -812,6 +812,10 @@ jobs:
           repository: ${{ matrix.target.sfa_repo }}
           ref: ${{ matrix.target.sfa_branch }}
           path: sing-box-for-android
+          # termux-app submodule is required: settings.gradle.kts includes
+          # :terminal-view/:terminal-emulator under third_party/termux-app.
+          # Gradle 9.3.1+ hard-fails configuring a project whose dir is missing.
+          submodules: true
 
       - name: Setup Go
         if: matrix.target.sfa_repo != 'none'
@@ -1845,7 +1849,7 @@ jobs:
       - name: Create Issue with logs
         run: |
           echo "Fetching failed logs..."
-          gh run view ${{ github.run_id }} --repo "${{ github.repository }}" --log-failed --exit-status 0 | tail -n 100 > /tmp/error.log || echo "Failed to fetch logs." > /tmp/error.log
+          gh run view ${{ github.run_id }} --repo "${{ github.repository }}" --log-failed 2>/tmp/gh_err.log | tail -n 100 > /tmp/error.log || echo "Failed to fetch logs: $(cat /tmp/gh_err.log)" > /tmp/error.log
 
           cat > issue_body.md <<EOF
           構建在工作流 \`${{ github.workflow }}\` 中失敗。


### PR DESCRIPTION
## 根因

`build_android (reF1nd_Testing)` 自 ~2026-05-17 起每日定时构建失败：

```
* What went wrong:
Configuring project ':terminal-view' without an existing directory is not allowed.
The configured project directory '.../sing-box-for-android/third_party/termux-app/terminal-view'
does not exist, can't be written to or is not a directory.
BUILD FAILED in 9s
```

### 主因
`Checkout Android Client` 步骤使用 `actions/checkout@v4` 但**未设置 `submodules: true`**。
`sing-box-for-android` 的 `.gitmodules` 声明了 `third_party/termux-app` 子模块，
`settings.gradle.kts` 通过 `include(":terminal-view")` / `:terminal-emulator` 指向其中目录。
子模块未拉取 → 目录缺失 → **Gradle 9.3.1+（ubuntu-latest 近期升级）对缺失的 included projectDir 硬报错**。

> 注：`build_core`（19 个 job）全部通过，因为只跑 `go build`，不读 `settings.gradle.kts`，故对该问题无感。

### 次因（18 个 issue 错误日志全为空）
`create_issue_on_failure` 执行：
```bash
gh run view $RUN_ID --log-failed --exit-status 0 | tail -n 100 > /tmp/error.log || ...
```
`--exit-status` 是布尔 flag，尾部 `0` 被当作多余位置参数，`gh` 报 "accepts at most 1 arg" 且无 stdout 输出。
`| tail` 掩盖了 `gh` 的非零退出码（tail 返回 0），导致 `||` 兜底永不触发 → 所有失败 issue 的错误日志段为空。

## 修复

| 文件 | 改动 |
|---|---|
| `.github/workflows/build-sing-box.yml:810` | Android Client checkout 增加 `submodules: true`（SagerNet/termux-app 无嵌套子模块，单层即可） |
| `.github/workflows/build-sing-box.yml:1848` | 移除多余的 `--exit-status 0`；将 stderr 单独捕获，失败时写入 issue |

## 验证
- YAML 语法校验通过
- 待合并后由下次定时构建（或手动 workflow_dispatch）验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)