### PR TITLE
feat: add with_cloudflared/with_usbip tags + build-time patch mechanism

### DIFF
--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -76,7 +76,7 @@ permissions:
 
 env:
   GO_VERSION_PIN: ""
-  TAGS_COMMON: "badlinkname,tfogo_checklinkname0,with_gvisor,with_quic,with_dhcp,with_utls,with_clash_api,with_wireguard,with_tailscale"
+  TAGS_COMMON: "badlinkname,tfogo_checklinkname0,with_gvisor,with_quic,with_dhcp,with_utls,with_clash_api,with_wireguard,with_tailscale,with_cloudflared,with_usbip"
   TAGS_CLI_EXTRA: "with_acme,with_ccm,with_ocm"
   TAGS_SFA_EXTRA: "ts_omit_logtail,ts_omit_ssh,ts_omit_drive,ts_omit_taildrop,ts_omit_webclient,ts_omit_doctor,ts_omit_capture,ts_omit_kube,ts_omit_aws,ts_omit_synology,ts_omit_bird"
   TAGS_ANDROID_EXTRA: "with_conntrack"
@@ -395,6 +395,23 @@ jobs:
           ref: ${{ steps.resolve.outputs.ref }}
           path: sing-box
           fetch-depth: 1
+
+      - name: Apply Patches
+        if: steps.check_naive.outputs.skip != 'true' && steps.filter.outputs.skip != 'true'
+        working-directory: sing-box
+        run: |
+          set -e
+          applied=0
+          for dir in "../patches/common" "../patches/${{ matrix.target.id }}"; do
+            [ -d "$dir" ] || continue
+            for p in "$dir"/*.patch; do
+              [ -f "$p" ] || continue
+              echo "::notice::Applying patch $(basename "$p")"
+              git apply -v "$p"
+              applied=$((applied+1))
+            done
+          done
+          echo "Applied $applied patch(es)."
 
       - name: Clean Workspace
         if: steps.check_naive.outputs.skip != 'true' && steps.filter.outputs.skip != 'true'
@@ -804,6 +821,23 @@ jobs:
           path: sing-box
           fetch-depth: 0
           filter: blob:none
+
+      - name: Apply Patches
+        if: matrix.target.sfa_repo != 'none'
+        working-directory: sing-box
+        run: |
+          set -e
+          applied=0
+          for dir in "../patches/common" "../patches/${{ matrix.target.id }}"; do
+            [ -d "$dir" ] || continue
+            for p in "$dir"/*.patch; do
+              [ -f "$p" ] || continue
+              echo "::notice::Applying patch $(basename "$p")"
+              git apply -v "$p"
+              applied=$((applied+1))
+            done
+          done
+          echo "Applied $applied patch(es)."
 
       - name: Checkout Android Client
         if: matrix.target.sfa_repo != 'none'

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,52 @@
+# Patches
+
+This directory contains **build-time patches** applied to the sing-box core source code
+before compilation. Patches are applied on the fly by the CI workflow — no fork needed.
+
+## Directory Layout
+
+```
+patches/
+  README.md
+  common/           # Applied to ALL targets (Stable + Testing)
+    *.patch
+  reF1nd_Stable/    # Applied ONLY to reF1nd_Stable builds
+    *.patch
+  reF1nd_Testing/   # Applied ONLY to reF1nd_Testing builds
+    *.patch
+```
+
+## How to Add a Patch
+
+1. Make your change inside a lokal checkout of
+   [`reF1nd/sing-box`](https://github.com/reF1nd/sing-box).
+2. Generate the patch:
+   ```bash
+   git diff > my-change.patch
+   # or for a single commit:
+   git format-patch -1 HEAD
+   ```
+3. Place the `.patch` file in the appropriate subdirectory above.
+4. Commit and push. The workflow applies it automatically.
+
+## Patch Requirements
+
+- **Path-relative to sing-box root.** A diff hunk referencing
+  `a/cmd/sing-box/main.go` is applied to
+  `sing-box/cmd/sing-box/main.go` inside the CI checkout.
+- **Must apply cleanly.** Patch failure is a hard build error.
+  If upstream code changes break the patch, update or remove it.
+- **Plain `git diff` format.** Context lines, hunks, standard unified diff.
+
+## Verification
+
+After adding a patch, trigger a `workflow_dispatch` build and verify
+the "Apply Patches" step in the log:
+
+```
+::notice::Applying patch my-change.patch
+Applied 1 patch(es).
+```
+
+If a patch fails, the build stops immediately with an error showing
+which file/hunk conflicted.


### PR DESCRIPTION
## C1: 補齊 build tags

`TAGS_COMMON` 追加 `with_cloudflared,with_usbip`，對齊 reF1nd 上游規範 `release/DEFAULT_BUILD_TAGS_OTHERS`：
- `with_cloudflared` → `cloudflared` 出站（Cloudflare Tunnel）
- `with_usbip` → USB/IP 隧道支持

依賴已在 reF1nd go.mod（`sing-cloudflared`、`sing-usbip`），僅加編譯標籤。

## C2: 構建時補丁機制

借鑑 yagh779/sing-box-releases 模式，新增 `patches/` 目錄：
- `patches/common/` — 應用於所有 target
- `patches/reF1nd_Stable/` — 僅 Stable
- `patches/reF1nd_Testing/` — 僅 Testing
- `patches/README.md` — 使用說明

在 `build_core` 和 `build_android` 的 Checkout Core 後插入 **Apply Patches** 步驟。補丁失敗 → 硬中斷構建。初始空目錄，不改變任何產物。

## 驗證

- YAML 語法 ✅
- 觸發 workflow_dispatch 後確認 `build_core` 19 job 全部通過（含 with_cloudflared/with_usbip 編譯）

🤖 Generated with [Claude Code](https://claude.com/claude-code)