### PR TITLE
feat(apple): add SFM (macOS) build, drop continue-on-error, fix build_apple

### DIFF
--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1114,7 +1114,7 @@ jobs:
       - name: Apply Patches
         working-directory: sing-box
         run: |
-          set -e
+          set -euo pipefail
           applied=0
           for dir in "../patches/common" "../patches/${{ matrix.target.id }}"; do
             [ -d "$dir" ] || continue
@@ -1211,9 +1211,11 @@ jobs:
           # ldid sign main binary with macOS entitlements
           ldid -SSFM/SFM.entitlements "$APP_PATH/Contents/MacOS/sing-box"
           # Sign any .appex plugins if present (macOS NE via System Extensions)
+          shopt -s nullglob
           for ex in "$APP_PATH/Contents/Plugins/"*.appex; do
-            [ -f "$ex" ] && ldid -S "$ex" 2>/dev/null || true
+            ldid -S "$ex" 2>/dev/null || true
           done
+          shopt -u nullglob
 
           # Package as .zip (macOS .app bundle, not TrollStore .tipa)
           mkdir -p packages

--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1059,7 +1059,7 @@ jobs:
     runs-on: macos-latest
     needs: [init, check]
     timeout-minutes: 60
-    # 非阻塞：Apple 構建失敗不影響 core/android 發佈（簽名/環境複雜，符合 A2 未簽名取捨）
+    # 非阻塞：Apple 構建失敗不影響 core/android 發佈
     continue-on-error: true
     if: >-
       needs.check.outputs.has_update == 'true' &&
@@ -1071,7 +1071,7 @@ jobs:
       matrix:
         target: ${{ fromJson(needs.check.outputs.matrix) }}
     steps:
-      - name: Checkout Core
+      - name: Checkout Core (with Apple client submodule)
         uses: actions/checkout@v4
         with:
           repository: ${{ matrix.target.repo }}
@@ -1079,6 +1079,10 @@ jobs:
           path: sing-box
           fetch-depth: 0
           filter: blob:none
+          # reF1nd/sing-box 把 SagerNet/sing-box-for-apple pin 在 clients/apple 子模塊
+          # (兼容 commit)。隨 core 拉取子模塊，Apple client Swift API 與 reF1nd libbox
+          # 保證同版本匹配——勿單獨 checkout Apple client main 分支（API 已演進不兼容）。
+          submodules: true
 
       - name: Apply Patches
         working-directory: sing-box
@@ -1103,100 +1107,72 @@ jobs:
           cache: true
           cache-dependency-path: 'sing-box/go.sum'
 
-      - name: Build Libbox.xcframework
+      - name: Install ldid
+        run: brew install ldid
+
+      - name: Build Libbox.xcframework (iOS)
         working-directory: sing-box
         run: |
           make lib_install
-          make lib_apple
+          export PATH="$PATH:$(go env GOPATH)/bin"
+          # -platform ios 精確產出 iOS xcframework（優於 make lib_apple 的全平台）
+          go run ./cmd/internal/build_libbox -target apple -platform ios
+          mv Libbox.xcframework clients/apple
 
-      - name: Resolve Apple Client Branch
-        id: apple_ref
+      - name: Build SFI (iOS, unsigned + ldid)
+        working-directory: sing-box/clients/apple
         run: |
-          # reF1nd 未 fork Apple client → 用上游 SagerNet/sing-box-for-apple
-          # stable target 映射 stable 分支，testing target 映射 main 分支
-          if [[ "${{ matrix.target.id }}" == *"Stable"* ]]; then
-            echo "ref=stable" >> $GITHUB_OUTPUT
-          else
-            echo "ref=main" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Checkout Apple Client
-        uses: actions/checkout@v4
-        with:
-          repository: SagerNet/sing-box-for-apple
-          ref: ${{ steps.apple_ref.outputs.ref }}
-          path: sing-box-for-apple
-          submodules: true
-
-      - name: Place Libbox.xcframework
-        run: |
-          # make lib_apple 產物路徑自適應定位（可能在 sing-box/ 根或 dist/）
-          XCFW=$(find sing-box -maxdepth 3 -name "Libbox.xcframework" -type d 2>/dev/null | head -1)
-          if [ -z "$XCFW" ]; then
-            echo "::error::Libbox.xcframework not found after make lib_apple"
-            exit 1
-          fi
-          echo "Found xcframework at: $XCFW"
-          # pbxproj 引用 path=Libbox.xcframework, sourceTree="<group>" → 項目根目錄
-          # (非 Frameworks/ 下；Xcode 在 sing-box-for-apple/Libbox.xcframework 查找)
-          DEST="sing-box-for-apple/Libbox.xcframework"
-          rm -rf "$DEST"
-          cp -R "$XCFW" "$DEST"
-
-      - name: Build SFI (iOS, unsigned)
-        working-directory: sing-box-for-apple
-        run: |
-          set -o pipefail
-          # -derivedDataPath 固定輸出路徑，CODE_SIGNING_ALLOWED=NO 走未簽名
-          xcodebuild build \
-            -scheme SFI -configuration Release \
+          set -euo pipefail
+          xcodebuild \
+            -project sing-box.xcodeproj \
+            -scheme SFI \
             -destination 'generic/platform=iOS' \
-            -derivedDataPath build/dd \
-            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" \
-            | xcbeautify || true
-          # 用產物存在性校驗（xcbeautify exit code 不可靠）
-          APP=$(find build/dd -name "SFI.app" -type d 2>/dev/null | head -1)
-          [ -n "$APP" ] || { echo "::error::SFI.app not produced"; exit 1; }
-          echo "SFI.app at: $APP"
+            -configuration Release \
+            -sdk iphoneos \
+            -derivedDataPath DerivedData \
+            build \
+            STRIP_INSTALLED_PRODUCT=NO \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO
 
-      - name: Build SFM (macOS, unsigned)
-        working-directory: sing-box-for-apple
-        run: |
-          set -o pipefail
-          xcodebuild build \
-            -scheme SFM -configuration Release \
-            -destination 'generic/platform=macOS' \
-            -derivedDataPath build/dd \
-            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" \
-            | xcbeautify || true
-          APP=$(find build/dd -name "SFM.app" -type d 2>/dev/null | head -1)
-          [ -n "$APP" ] || { echo "::error::SFM.app not produced"; exit 1; }
-          echo "SFM.app at: $APP"
+          APP_PATH="DerivedData/Build/Products/Release-iphoneos/sing-box.app"
+          [ -d "$APP_PATH" ] || { echo "::error::sing-box.app not produced"; exit 1; }
 
-      - name: Collect .app Artifacts
+          # ldid 簽 entitlements（ad-hoc，TrollStore/越獄安裝用，非 Apple codesign）
+          ldid -SSFI/SFI.entitlements "$APP_PATH/sing-box"
+          ldid -SExtension/Extension.entitlements "$APP_PATH/PlugIns/Extension.appex/Extension" 2>/dev/null || true
+          ldid -SIntentsExtension/IntentsExtension.entitlements "$APP_PATH/Extensions/IntentsExtension.appex/IntentsExtension" 2>/dev/null || true
+
+          # 打包 .tipa（TrollStore 可直接安裝）
+          mkdir -p packages/Payload
+          cp -rp "$APP_PATH" packages/Payload
+          cd packages
+          zip -qr sing-box.tipa Payload
+
+      - name: Collect Apple Artifacts
         run: |
           mkdir -p apple-out
           VER="${{ matrix.target.ver }}"
           TID="${{ matrix.target.id }}"
-          cd sing-box-for-apple
-          for app in $(find build/dd -maxdepth 5 -name "SFI.app" -type d 2>/dev/null); do
-            tar czf "../apple-out/SFI-${TID}-${VER}.app.tar.gz" -C "$(dirname "$app")" SFI.app
-            break
-          done
-          for app in $(find build/dd -maxdepth 5 -name "SFM.app" -type d 2>/dev/null); do
-            tar czf "../apple-out/SFM-${TID}-${VER}.app.tar.gz" -C "$(dirname "$app")" SFM.app
-            break
-          done
-          cd ..
-          echo "=== apple-out ==="
+          TIPA="sing-box/clients/apple/packages/sing-box.tipa"
+          if [ -f "$TIPA" ]; then
+            mv "$TIPA" "apple-out/SFI-${TID}-${VER}.tipa"
+            echo "Produced SFI-${TID}-${VER}.tipa"
+          else
+            echo "::error::SFI .tipa not produced"
+            exit 1
+          fi
           ls -la apple-out/
-          [ -z "$(ls apple-out/*.tar.gz 2>/dev/null)" ] && { echo "::error::No .app.tar.gz produced"; exit 1; }
 
       - name: Upload Apple Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: apple-${{ matrix.target.id }}
-          path: apple-out/*.tar.gz
+          path: apple-out/*.tipa
           retention-days: 1
           compression-level: 0
 
@@ -1405,11 +1381,11 @@ jobs:
             # Apple 產物（build_apple 非阻塞，產物可能缺席）
             apple_dir="./tmp/apple-${target_id}"
             if [[ -d "$apple_dir" ]]; then
-              for app_tgz in "$apple_dir"/*.tar.gz; do
-                [ -f "$app_tgz" ] || continue
-                APP_NAME=$(basename "$app_tgz")
-                cp "$app_tgz" "release_files/${target_id}/apple/${APP_NAME}"
-                APPLE_FILES["$APP_NAME"]="$APP_NAME"
+              for tipa in "$apple_dir"/*.tipa; do
+                [ -f "$tipa" ] || continue
+                TIPA_NAME=$(basename "$tipa")
+                cp "$tipa" "release_files/${target_id}/apple/${TIPA_NAME}"
+                APPLE_FILES["$TIPA_NAME"]="$TIPA_NAME"
               done
             fi
 
@@ -1519,15 +1495,15 @@ jobs:
             if [ ${#APPLE_FILES[@]} -gt 0 ]; then
               echo "" >> release_body.txt
               echo "<details>" >> release_body.txt
-              echo "<summary><b>🍎 Apple 產物（未簽名）</b></summary>" >> release_body.txt
+              echo "<summary><b>🍎 Apple 產物（未簽名 .tipa）</b></summary>" >> release_body.txt
               echo "" >> release_body.txt
-              echo "> ⚠️ 未簽名 .app，需 TrollStore/sideload 工具安裝，不可直接安裝。" >> release_body.txt
+              echo "> ⚠️ ldid ad-hoc 簽名的 .tipa，需 TrollStore/sideload 安裝，不可直接安裝。" >> release_body.txt
               echo "" >> release_body.txt
               echo "| 類型 | 文件名 |" >> release_body.txt
               echo "|------|--------|" >> release_body.txt
               for key in "${!APPLE_FILES[@]}"; do
                 file_name="${APPLE_FILES[$key]}"
-                echo "| Apple .app | \`${file_name}\` |" >> release_body.txt
+                echo "| iOS .tipa | \`${file_name}\` |" >> release_body.txt
               done
               echo "</details>" >> release_body.txt
             fi
@@ -1541,7 +1517,7 @@ jobs:
 
             (
               cd "release_files/${target_id}"
-              find . -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.apk" -o -name "*.upx" -o -name "*.app.tar.gz" \) -exec sha256sum {} \; | sed 's/ \.\// /' > SHA256SUMS.txt
+              find . -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.apk" -o -name "*.upx" -o -name "*.tipa" \) -exec sha256sum {} \; | sed 's/ \.\// /' > SHA256SUMS.txt
             )
             echo "" >> release_body.txt
             echo "## 🔐 SHA256 Checksums" >> release_body.txt
@@ -1565,7 +1541,7 @@ jobs:
               release_files/${target_id}/**/*.zip
               release_files/${target_id}/**/*.apk
               release_files/${target_id}/**/*.upx
-              release_files/${target_id}/**/*.app.tar.gz
+              release_files/${target_id}/**/*.tipa
             )
             shopt -u nullglob globstar
             [ -f "release_files/${target_id}/linux/install-linux.sh" ] && FILES+=("release_files/${target_id}/linux/install-linux.sh")
@@ -1597,7 +1573,7 @@ jobs:
             release_files/**/*.zip
             release_files/**/*.apk
             release_files/**/*.upx
-            release_files/**/*.app.tar.gz
+            release_files/**/*.tipa
 
       - name: Upload Build Info Artifact
         if: always()
@@ -1782,6 +1758,9 @@ jobs:
   telegram_notify:
     needs: [build_core, build_android, build_apple, publish, finalize]
     runs-on: ubuntu-latest
+    # xz-dev/TelegramFileUploader 上傳大文件無內部超時，網絡問題時會無限 hang；
+    # 給 job 級超時，避免佔用 runner 到 6h 上限。Telegram 推送正常幾秒完成。
+    timeout-minutes: 15
     if: always() && (github.event.inputs.enable_telegram == 'true' || github.event_name == 'schedule')
     steps:
       - name: Generate Telegram Message

--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1250,7 +1250,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [init, check, build_core, build_android, build_apple]
-    # build_apple 有 continue-on-error，其失敗不阻塞 publish；不要求 apple 成功
+    # Apple build now blocks the workflow; publish runs via always() guards
     if: >-
       always() &&
       needs.check.outputs.has_update == 'true' &&

--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1056,7 +1056,7 @@ jobs:
           compression-level: 0
 
   build_apple:
-    runs-on: macos-latest
+    runs-on: macos-26
     needs: [init, check]
     timeout-minutes: 60
     # 非阻塞：Apple 構建失敗不影響 core/android 發佈
@@ -1106,13 +1106,12 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          # Apple 構建鎖 Go 1.25.x（不用 init 的動態最新版，也不用 ^1.25——後者
-          # 在 setup-go 是 >=1.25 <2.0，會裝到 1.26.x）。
-          # Go 1.26 下 gomobile 生成的 Libbox Swift bindings 缺
-          # LibboxSetMemoryLimit/LibboxRedirectStderr 等符號，xcodebuild 報
-          # "cannot find ... in scope"。1.25.x 驗證可行（jsda/sing-box-for-ios）。
-          # reF1nd go.mod 聲明 go 1.24.7，1.25.x 向後兼容。
-          go-version: '1.25.11'
+          # Apple 構建用 init 的動態 Go 版本（jsda 用 1.26.4 成功，Go 版本非因素）。
+          # 真正的約束是 Xcode：Apple client 用了 Swift 6 `isolated deinit` 特性，
+          # 需 Xcode 26.x（macos-26 runner 自帶 Xcode 26.5）。macos-latest 的 Xcode 16.4
+          # 報 'isolated' deinit requires frontend flag + LibboxStringIteratorProtocol
+          # has no member 'value' 等編譯器類型推導問題。
+          go-version: ${{ needs.init.outputs.go_version }}
           cache: false
           cache-dependency-path: 'sing-box/go.sum'
 

--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1202,12 +1202,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [init, check, build_core, build_android, build_apple]
+    # build_apple 有 continue-on-error，其失敗不阻塞 publish；不要求 apple 成功
     if: >-
       always() &&
       needs.check.outputs.has_update == 'true' &&
       !cancelled() &&
       (needs.build_core.result == 'success' || needs.build_android.result == 'success')
-      # build_apple 有 continue-on-error，其失敗不阻塞 publish；不要求 apple 成功
     outputs:
       release_version: ${{ steps.prepare.outputs.release_version }}
     steps:

--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1106,12 +1106,13 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          # Apple 構建鎖 Go 1.25.x（不用 init 的動態最新版）。
-          # Go 1.26 下 gomobile 生成的 Libbox Swift bindings 會缺
+          # Apple 構建鎖 Go 1.25.x（不用 init 的動態最新版，也不用 ^1.25——後者
+          # 在 setup-go 是 >=1.25 <2.0，會裝到 1.26.x）。
+          # Go 1.26 下 gomobile 生成的 Libbox Swift bindings 缺
           # LibboxSetMemoryLimit/LibboxRedirectStderr 等符號，xcodebuild 報
-          # "cannot find ... in scope"。jsda/sing-box-for-ios 用 ^1.25 驗證可行。
+          # "cannot find ... in scope"。1.25.x 驗證可行（jsda/sing-box-for-ios）。
           # reF1nd go.mod 聲明 go 1.24.7，1.25.x 向後兼容。
-          go-version: ^1.25
+          go-version: '1.25.11'
           cache: false
           cache-dependency-path: 'sing-box/go.sum'
 

--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1059,8 +1059,6 @@ jobs:
     runs-on: macos-26
     needs: [init, check]
     timeout-minutes: 60
-    # 非阻塞：Apple 構建失敗不影響 core/android 發佈
-    continue-on-error: true
     if: >-
       needs.check.outputs.has_update == 'true' &&
       needs.check.outputs.matrix != '[]' &&
@@ -1144,13 +1142,15 @@ jobs:
       - name: Install ldid
         run: brew install ldid
 
-      - name: Build Libbox.xcframework (iOS)
+      - name: Build Libbox.xcframework (Apple)
         working-directory: sing-box
         run: |
           make lib_install
           export PATH="$PATH:$(go env GOPATH)/bin"
-          # -platform ios 精確產出 iOS xcframework（優於 make lib_apple 的全平台）
-          go run ./cmd/internal/build_libbox -target apple -platform ios
+          # No -platform flag → builds universal xcframework for
+          # ios,iossimulator,tvos,tvossimulator,macos so both SFI (iOS)
+          # and SFM (macOS) can link against the same framework.
+          go run ./cmd/internal/build_libbox -target apple
           mv Libbox.xcframework clients/apple
 
       - name: Build SFI (iOS, unsigned + ldid)
@@ -1187,18 +1187,54 @@ jobs:
           cd packages
           zip -qr sing-box.tipa Payload
 
+      - name: Build SFM (macOS, unsigned + ldid)
+        working-directory: sing-box/clients/apple
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -project sing-box.xcodeproj \
+            -scheme SFM \
+            -destination 'generic/platform=macOS' \
+            -configuration Release \
+            -sdk macosx \
+            -derivedDataPath DerivedData \
+            build \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            SWIFT_SERIALIZE_DEBUGGING_OPTIONS=NO
+
+          APP_PATH="DerivedData/Build/Products/Release/sing-box.app"
+          [ -d "$APP_PATH" ] || { echo "::error::sing-box.app (macOS) not produced"; exit 1; }
+
+          # ldid sign main binary with macOS entitlements
+          ldid -SSFM/SFM.entitlements "$APP_PATH/Contents/MacOS/sing-box"
+          # Sign any .appex plugins if present (macOS NE via System Extensions)
+          for ex in "$APP_PATH/Contents/Plugins/"*.appex; do
+            [ -f "$ex" ] && ldid -S "$ex" 2>/dev/null || true
+          done
+
+          # Package as .zip (macOS .app bundle, not TrollStore .tipa)
+          mkdir -p packages
+          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" packages/sing-box.zip
+
       - name: Collect Apple Artifacts
         run: |
           mkdir -p apple-out
           VER="${{ matrix.target.ver }}"
           TID="${{ matrix.target.id }}"
-          TIPA="sing-box/clients/apple/packages/sing-box.tipa"
-          if [ -f "$TIPA" ]; then
-            mv "$TIPA" "apple-out/SFI-${TID}-${VER}.tipa"
+          SFI_TIPA="sing-box/clients/apple/packages/sing-box.tipa"
+          SFM_ZIP="sing-box/clients/apple/packages/sing-box.zip"
+          if [ -f "$SFI_TIPA" ]; then
+            mv "$SFI_TIPA" "apple-out/SFI-${TID}-${VER}.tipa"
             echo "Produced SFI-${TID}-${VER}.tipa"
           else
             echo "::error::SFI .tipa not produced"
             exit 1
+          fi
+          if [ -f "$SFM_ZIP" ]; then
+            mv "$SFM_ZIP" "apple-out/SFM-${TID}-${VER}.zip"
+            echo "Produced SFM-${TID}-${VER}.zip"
           fi
           ls -la apple-out/
 
@@ -1206,7 +1242,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: apple-${{ matrix.target.id }}
-          path: apple-out/*.tipa
+          path: apple-out/*
           retention-days: 1
           compression-level: 0
 
@@ -1412,14 +1448,14 @@ jobs:
               cp "$apk_dir"/*-metadata.json "release_files/${target_id}/android/" 2>/dev/null || true
             fi
 
-            # Apple 產物（build_apple 非阻塞，產物可能缺席）
+            # Apple 產物（.tipa for iOS TrollStore, .zip for macOS .app）
             apple_dir="./tmp/apple-${target_id}"
             if [[ -d "$apple_dir" ]]; then
-              for tipa in "$apple_dir"/*.tipa; do
-                [ -f "$tipa" ] || continue
-                TIPA_NAME=$(basename "$tipa")
-                cp "$tipa" "release_files/${target_id}/apple/${TIPA_NAME}"
-                APPLE_FILES["$TIPA_NAME"]="$TIPA_NAME"
+              for f in "$apple_dir"/SFI-*.tipa "$apple_dir"/SFM-*.zip; do
+                [ -f "$f" ] || continue
+                FNAME=$(basename "$f")
+                cp "$f" "release_files/${target_id}/apple/${FNAME}"
+                APPLE_FILES["$FNAME"]="$FNAME"
               done
             fi
 
@@ -1529,15 +1565,19 @@ jobs:
             if [ ${#APPLE_FILES[@]} -gt 0 ]; then
               echo "" >> release_body.txt
               echo "<details>" >> release_body.txt
-              echo "<summary><b>🍎 Apple 產物（未簽名 .tipa）</b></summary>" >> release_body.txt
+              echo "<summary><b>🍎 Apple 產物（未簽名）</b></summary>" >> release_body.txt
               echo "" >> release_body.txt
-              echo "> ⚠️ ldid ad-hoc 簽名的 .tipa，需 TrollStore/sideload 安裝，不可直接安裝。" >> release_body.txt
+              echo "> ⚠️ ldid ad-hoc 簽名，非 Apple 公證。iOS .tipa 需 TrollStore/sideload。" >> release_body.txt
               echo "" >> release_body.txt
               echo "| 類型 | 文件名 |" >> release_body.txt
               echo "|------|--------|" >> release_body.txt
               for key in "${!APPLE_FILES[@]}"; do
                 file_name="${APPLE_FILES[$key]}"
-                echo "| iOS .tipa | \`${file_name}\` |" >> release_body.txt
+                if [[ "$file_name" == *.tipa ]]; then
+                  echo "| iOS .tipa | \`${file_name}\` |" >> release_body.txt
+                else
+                  echo "| macOS .zip | \`${file_name}\` |" >> release_body.txt
+                fi
               done
               echo "</details>" >> release_body.txt
             fi

--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1077,8 +1077,12 @@ jobs:
           repository: ${{ matrix.target.repo }}
           ref: ${{ matrix.target.core_ref }}
           path: sing-box
-          fetch-depth: 0
-          filter: blob:none
+          # 用 shallow clone（不用 fetch-depth:0 + filter:blob:none）。
+          # filter:blob:none 的 partial clone 會延遲加載 blob；gomobile build_libbox
+          # 掃描 libbox 導出符號時若某些 Go 源文件 blob 未拉，生成的 Swift bindings 會
+          # 靜默缺符號（LibboxSetMemoryLimit/LibboxRedirectStderr），xcframework 生成
+          # 成功但 xcodebuild 報 "cannot find ... in scope"。jsda 用 --depth 1 完整拉取。
+          fetch-depth: 1
           # reF1nd/sing-box 把 SagerNet/sing-box-for-apple pin 在 clients/apple 子模塊
           # (兼容 commit)。隨 core 拉取子模塊，Apple client Swift API 與 reF1nd libbox
           # 保證同版本匹配——勿單獨 checkout Apple client main 分支（API 已演進不兼容）。

--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1106,8 +1106,13 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ needs.init.outputs.go_version }}
-          cache: true
+          # Apple 構建鎖 Go 1.25.x（不用 init 的動態最新版）。
+          # Go 1.26 下 gomobile 生成的 Libbox Swift bindings 會缺
+          # LibboxSetMemoryLimit/LibboxRedirectStderr 等符號，xcodebuild 報
+          # "cannot find ... in scope"。jsda/sing-box-for-ios 用 ^1.25 驗證可行。
+          # reF1nd go.mod 聲明 go 1.24.7，1.25.x 向後兼容。
+          go-version: ^1.25
+          cache: false
           cache-dependency-path: 'sing-box/go.sum'
 
       - name: Install ldid

--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1199,6 +1199,7 @@ jobs:
             -sdk macosx \
             -derivedDataPath DerivedData \
             build \
+            -skipPackagePluginValidation \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             COMPILER_INDEX_STORE_ENABLE=NO \

--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1137,8 +1137,9 @@ jobs:
             exit 1
           fi
           echo "Found xcframework at: $XCFW"
-          DEST="sing-box-for-apple/Frameworks/Libbox.xcframework"
-          mkdir -p "$DEST"
+          # pbxproj 引用 path=Libbox.xcframework, sourceTree="<group>" → 項目根目錄
+          # (非 Frameworks/ 下；Xcode 在 sing-box-for-apple/Libbox.xcframework 查找)
+          DEST="sing-box-for-apple/Libbox.xcframework"
           rm -rf "$DEST"
           cp -R "$XCFW" "$DEST"
 

--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1071,25 +1071,31 @@ jobs:
       matrix:
         target: ${{ fromJson(needs.check.outputs.matrix) }}
     steps:
-      - name: Checkout Core (with Apple client submodule)
+      - name: Checkout Core
         uses: actions/checkout@v4
         with:
           repository: ${{ matrix.target.repo }}
           ref: ${{ matrix.target.core_ref }}
           path: sing-box
-          # 用 shallow clone（不用 fetch-depth:0 + filter:blob:none）。
-          # filter:blob:none 的 partial clone 會延遲加載 blob；gomobile build_libbox
-          # 掃描 libbox 導出符號時若某些 Go 源文件 blob 未拉，生成的 Swift bindings 會
-          # 靜默缺符號（LibboxSetMemoryLimit/LibboxRedirectStderr），xcframework 生成
-          # 成功但 xcodebuild 報 "cannot find ... in scope"。jsda 用 --depth 1 完整拉取。
           fetch-depth: 1
-          # reF1nd/sing-box 把 SagerNet/sing-box-for-apple pin 在 clients/apple 子模塊
-          # (兼容 commit)。隨 core 拉取子模塊，Apple client Swift API 與 reF1nd libbox
-          # 保證同版本匹配——勿單獨 checkout Apple client main 分支（API 已演進不兼容）。
-          # recursive: clients/apple 內部還有 Frameworks/Runestone 子模塊（Swift Package
-          # 源碼），單層 true 只拉一層會導致 Runestone/Package.swift 缺失，xcodebuild
-          # 報 "Could not resolve package dependencies"。
-          submodules: recursive
+          # clients/apple submodule comes with core but is stale vs reF1nd libbox API;
+          # the next step replaces it with latest upstream. Shallow full fetch (no
+          # filter:blob:none) so libbox export symbols aren't dropped.
+
+      - name: Replace Apple client with latest upstream
+        working-directory: sing-box
+        run: |
+          set -euo pipefail
+          # reF1nd pins clients/apple at a stale SagerNet/sing-box-for-apple commit whose
+          # Swift LibboxPlatformInterfaceProtocol conformance + LibboxSetMemoryLimit /
+          # LibboxRedirectStderr calls lag reF1nd's libbox API → "does not conform to
+          # protocol" + "cannot find ... in scope" at xcodebuild. Replace it with the
+          # latest upstream dev branch, which implements the current protocol and uses
+          # LibboxSetupOptions.oomMemoryLimit. This is the jsda/sing-box-for-ios
+          # update_apple pattern. --recurse-submodules pulls the nested
+          # Frameworks/Runestone submodule so the SwiftPM Package.swift resolves.
+          rm -rf clients/apple
+          git clone --recurse-submodules --depth 1 https://github.com/SagerNet/sing-box-for-apple.git clients/apple
 
       - name: Apply Patches
         working-directory: sing-box

--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1078,24 +1078,40 @@ jobs:
           ref: ${{ matrix.target.core_ref }}
           path: sing-box
           fetch-depth: 1
-          # clients/apple submodule comes with core but is stale vs reF1nd libbox API;
-          # the next step replaces it with latest upstream. Shallow full fetch (no
-          # filter:blob:none) so libbox export symbols aren't dropped.
+          # Shallow full fetch (no filter:blob:none) so libbox export symbols aren't
+          # dropped. submodules: recursive pulls clients/apple (pinned by reF1nd to a
+          # SagerNet/sing-box-for-apple commit) plus its nested Frameworks/Runestone
+          # submodule so the SwiftPM Package.swift resolves. For cores on the *new*
+          # libbox API the next step replaces this pinned client with latest upstream.
+          submodules: recursive
 
-      - name: Replace Apple client with latest upstream
+      - name: Sync Apple client to core's libbox API version
         working-directory: sing-box
         run: |
           set -euo pipefail
-          # reF1nd pins clients/apple at a stale SagerNet/sing-box-for-apple commit whose
-          # Swift LibboxPlatformInterfaceProtocol conformance + LibboxSetMemoryLimit /
-          # LibboxRedirectStderr calls lag reF1nd's libbox API → "does not conform to
-          # protocol" + "cannot find ... in scope" at xcodebuild. Replace it with the
-          # latest upstream dev branch, which implements the current protocol and uses
-          # LibboxSetupOptions.oomMemoryLimit. This is the jsda/sing-box-for-ios
-          # update_apple pattern. --recurse-submodules pulls the nested
-          # Frameworks/Runestone submodule so the SwiftPM Package.swift resolves.
-          rm -rf clients/apple
-          git clone --recurse-submodules --depth 1 https://github.com/SagerNet/sing-box-for-apple.git clients/apple
+          # reF1nd pins clients/apple at SagerNet/sing-box-for-apple 794eb1741f, which
+          # matches reF1nd-stable's *old* libbox API (SagerNet stable v1.13.14 ships the
+          # same pin). But reF1nd-testing's libbox evolved: PlatformInterface gained
+          # openShellSession/usePlatformShell/startNeighborMonitor/lookupUser/etc and
+          # CommandClientHandler gained writeOutbounds, and it dropped LibboxSetMemoryLimit/
+          # LibboxRedirectStderr. The pinned 794eb1741f client doesn't implement those →
+          # "does not conform to protocol" + "cannot find ... in scope".
+          #
+          # Conversely, the latest upstream dev client now references symbols the *old*
+          # stable libbox doesn't export (LibboxGoVersion, LibboxPromoteOOMDraft,
+          # LibboxCommandOutbounds, LibboxRemoteConnectionOptions, crashReportSource,
+          # oomKillerEnabled, ...), so blindly replacing breaks stable.
+          #
+          # Resolution: detect the core's libbox API era from its Go source and only
+          # replace the client when the core is on the new API. WriteOutbounds in
+          # command_client.go is the clean signal — it exists only on the new API.
+          if grep -q 'WriteOutbounds' experimental/libbox/command_client.go; then
+            echo "::notice::Core is on the new libbox API (WriteOutbounds present). Replacing pinned Apple client with latest upstream dev branch."
+            rm -rf clients/apple
+            git clone --recurse-submodules --depth 1 https://github.com/SagerNet/sing-box-for-apple.git clients/apple
+          else
+            echo "::notice::Core is on the old libbox API (no WriteOutbounds). Keeping reF1nd-pinned Apple client (matches this libbox era)."
+          fi
 
       - name: Apply Patches
         working-directory: sing-box

--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1082,7 +1082,10 @@ jobs:
           # reF1nd/sing-box 把 SagerNet/sing-box-for-apple pin 在 clients/apple 子模塊
           # (兼容 commit)。隨 core 拉取子模塊，Apple client Swift API 與 reF1nd libbox
           # 保證同版本匹配——勿單獨 checkout Apple client main 分支（API 已演進不兼容）。
-          submodules: true
+          # recursive: clients/apple 內部還有 Frameworks/Runestone 子模塊（Swift Package
+          # 源碼），單層 true 只拉一層會導致 Runestone/Package.swift 缺失，xcodebuild
+          # 報 "Could not resolve package dependencies"。
+          submodules: recursive
 
       - name: Apply Patches
         working-directory: sing-box

--- a/.github/workflows/build-sing-box.yml
+++ b/.github/workflows/build-sing-box.yml
@@ -1055,14 +1055,159 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  build_apple:
+    runs-on: macos-latest
+    needs: [init, check]
+    timeout-minutes: 60
+    # 非阻塞：Apple 構建失敗不影響 core/android 發佈（簽名/環境複雜，符合 A2 未簽名取捨）
+    continue-on-error: true
+    if: >-
+      needs.check.outputs.has_update == 'true' &&
+      needs.check.outputs.matrix != '[]' &&
+      needs.check.outputs.matrix != '' &&
+      github.event.inputs.enable_naive != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.check.outputs.matrix) }}
+    steps:
+      - name: Checkout Core
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ matrix.target.repo }}
+          ref: ${{ matrix.target.core_ref }}
+          path: sing-box
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Apply Patches
+        working-directory: sing-box
+        run: |
+          set -e
+          applied=0
+          for dir in "../patches/common" "../patches/${{ matrix.target.id }}"; do
+            [ -d "$dir" ] || continue
+            for p in "$dir"/*.patch; do
+              [ -f "$p" ] || continue
+              echo "::notice::Applying patch $(basename "$p")"
+              git apply -v "$p"
+              applied=$((applied+1))
+            done
+          done
+          echo "Applied $applied patch(es)."
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ needs.init.outputs.go_version }}
+          cache: true
+          cache-dependency-path: 'sing-box/go.sum'
+
+      - name: Build Libbox.xcframework
+        working-directory: sing-box
+        run: |
+          make lib_install
+          make lib_apple
+
+      - name: Resolve Apple Client Branch
+        id: apple_ref
+        run: |
+          # reF1nd 未 fork Apple client → 用上游 SagerNet/sing-box-for-apple
+          # stable target 映射 stable 分支，testing target 映射 main 分支
+          if [[ "${{ matrix.target.id }}" == *"Stable"* ]]; then
+            echo "ref=stable" >> $GITHUB_OUTPUT
+          else
+            echo "ref=main" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout Apple Client
+        uses: actions/checkout@v4
+        with:
+          repository: SagerNet/sing-box-for-apple
+          ref: ${{ steps.apple_ref.outputs.ref }}
+          path: sing-box-for-apple
+          submodules: true
+
+      - name: Place Libbox.xcframework
+        run: |
+          # make lib_apple 產物路徑自適應定位（可能在 sing-box/ 根或 dist/）
+          XCFW=$(find sing-box -maxdepth 3 -name "Libbox.xcframework" -type d 2>/dev/null | head -1)
+          if [ -z "$XCFW" ]; then
+            echo "::error::Libbox.xcframework not found after make lib_apple"
+            exit 1
+          fi
+          echo "Found xcframework at: $XCFW"
+          DEST="sing-box-for-apple/Frameworks/Libbox.xcframework"
+          mkdir -p "$DEST"
+          rm -rf "$DEST"
+          cp -R "$XCFW" "$DEST"
+
+      - name: Build SFI (iOS, unsigned)
+        working-directory: sing-box-for-apple
+        run: |
+          set -o pipefail
+          # -derivedDataPath 固定輸出路徑，CODE_SIGNING_ALLOWED=NO 走未簽名
+          xcodebuild build \
+            -scheme SFI -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -derivedDataPath build/dd \
+            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" \
+            | xcbeautify || true
+          # 用產物存在性校驗（xcbeautify exit code 不可靠）
+          APP=$(find build/dd -name "SFI.app" -type d 2>/dev/null | head -1)
+          [ -n "$APP" ] || { echo "::error::SFI.app not produced"; exit 1; }
+          echo "SFI.app at: $APP"
+
+      - name: Build SFM (macOS, unsigned)
+        working-directory: sing-box-for-apple
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -scheme SFM -configuration Release \
+            -destination 'generic/platform=macOS' \
+            -derivedDataPath build/dd \
+            CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" \
+            | xcbeautify || true
+          APP=$(find build/dd -name "SFM.app" -type d 2>/dev/null | head -1)
+          [ -n "$APP" ] || { echo "::error::SFM.app not produced"; exit 1; }
+          echo "SFM.app at: $APP"
+
+      - name: Collect .app Artifacts
+        run: |
+          mkdir -p apple-out
+          VER="${{ matrix.target.ver }}"
+          TID="${{ matrix.target.id }}"
+          cd sing-box-for-apple
+          for app in $(find build/dd -maxdepth 5 -name "SFI.app" -type d 2>/dev/null); do
+            tar czf "../apple-out/SFI-${TID}-${VER}.app.tar.gz" -C "$(dirname "$app")" SFI.app
+            break
+          done
+          for app in $(find build/dd -maxdepth 5 -name "SFM.app" -type d 2>/dev/null); do
+            tar czf "../apple-out/SFM-${TID}-${VER}.app.tar.gz" -C "$(dirname "$app")" SFM.app
+            break
+          done
+          cd ..
+          echo "=== apple-out ==="
+          ls -la apple-out/
+          [ -z "$(ls apple-out/*.tar.gz 2>/dev/null)" ] && { echo "::error::No .app.tar.gz produced"; exit 1; }
+
+      - name: Upload Apple Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: apple-${{ matrix.target.id }}
+          path: apple-out/*.tar.gz
+          retention-days: 1
+          compression-level: 0
+
   publish:
     runs-on: ubuntu-latest
-    needs: [init, check, build_core, build_android]
+    needs: [init, check, build_core, build_android, build_apple]
     if: >-
       always() &&
       needs.check.outputs.has_update == 'true' &&
       !cancelled() &&
       (needs.build_core.result == 'success' || needs.build_android.result == 'success')
+      # build_apple 有 continue-on-error，其失敗不阻塞 publish；不要求 apple 成功
     outputs:
       release_version: ${{ steps.prepare.outputs.release_version }}
     steps:
@@ -1168,10 +1313,10 @@ jobs:
             upstream_body=$(echo "$target" | jq -r '.body // ""')
             commit_msg=$(echo "$target" | jq -r '.msg // ""')
 
-            unset BUILDTAGS_MAP LINUX_FILES WINDOWS_FILES DARWIN_FILES ANDROID_FILES 2>/dev/null || true
-            declare -A BUILDTAGS_MAP=() LINUX_FILES=() WINDOWS_FILES=() DARWIN_FILES=() ANDROID_FILES=()
+            unset BUILDTAGS_MAP LINUX_FILES WINDOWS_FILES DARWIN_FILES ANDROID_FILES APPLE_FILES 2>/dev/null || true
+            declare -A BUILDTAGS_MAP=() LINUX_FILES=() WINDOWS_FILES=() DARWIN_FILES=() ANDROID_FILES=() APPLE_FILES=()
 
-            mkdir -p ./release_files/${target_id}/{linux,windows,darwin,android}
+            mkdir -p ./release_files/${target_id}/{linux,windows,darwin,android,apple}
 
             if [ "$PUBLISH_TYPE" = "versioned" ]; then
               if [[ "$target_id" == *"Testing"* ]]; then
@@ -1254,6 +1399,17 @@ jobs:
                 ANDROID_FILES["$APK_NAME"]="$APK_NAME"
               done
               cp "$apk_dir"/*-metadata.json "release_files/${target_id}/android/" 2>/dev/null || true
+            fi
+
+            # Apple 產物（build_apple 非阻塞，產物可能缺席）
+            apple_dir="./tmp/apple-${target_id}"
+            if [[ -d "$apple_dir" ]]; then
+              for app_tgz in "$apple_dir"/*.tar.gz; do
+                [ -f "$app_tgz" ] || continue
+                APP_NAME=$(basename "$app_tgz")
+                cp "$app_tgz" "release_files/${target_id}/apple/${APP_NAME}"
+                APPLE_FILES["$APP_NAME"]="$APP_NAME"
+              done
             fi
 
             cp /tmp/install-linux.sh release_files/${target_id}/linux/install-linux.sh
@@ -1359,6 +1515,22 @@ jobs:
               echo "</details>" >> release_body.txt
             fi
 
+            if [ ${#APPLE_FILES[@]} -gt 0 ]; then
+              echo "" >> release_body.txt
+              echo "<details>" >> release_body.txt
+              echo "<summary><b>🍎 Apple 產物（未簽名）</b></summary>" >> release_body.txt
+              echo "" >> release_body.txt
+              echo "> ⚠️ 未簽名 .app，需 TrollStore/sideload 工具安裝，不可直接安裝。" >> release_body.txt
+              echo "" >> release_body.txt
+              echo "| 類型 | 文件名 |" >> release_body.txt
+              echo "|------|--------|" >> release_body.txt
+              for key in "${!APPLE_FILES[@]}"; do
+                file_name="${APPLE_FILES[$key]}"
+                echo "| Apple .app | \`${file_name}\` |" >> release_body.txt
+              done
+              echo "</details>" >> release_body.txt
+            fi
+
             echo "" >> release_body.txt
             echo "---" >> release_body.txt
             echo "### 📜 History (歷史更新)" >> release_body.txt
@@ -1368,7 +1540,7 @@ jobs:
 
             (
               cd "release_files/${target_id}"
-              find . -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.apk" -o -name "*.upx" \) -exec sha256sum {} \; | sed 's/ \.\// /' > SHA256SUMS.txt
+              find . -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.apk" -o -name "*.upx" -o -name "*.app.tar.gz" \) -exec sha256sum {} \; | sed 's/ \.\// /' > SHA256SUMS.txt
             )
             echo "" >> release_body.txt
             echo "## 🔐 SHA256 Checksums" >> release_body.txt
@@ -1392,6 +1564,7 @@ jobs:
               release_files/${target_id}/**/*.zip
               release_files/${target_id}/**/*.apk
               release_files/${target_id}/**/*.upx
+              release_files/${target_id}/**/*.app.tar.gz
             )
             shopt -u nullglob globstar
             [ -f "release_files/${target_id}/linux/install-linux.sh" ] && FILES+=("release_files/${target_id}/linux/install-linux.sh")
@@ -1423,6 +1596,7 @@ jobs:
             release_files/**/*.zip
             release_files/**/*.apk
             release_files/**/*.upx
+            release_files/**/*.app.tar.gz
 
       - name: Upload Build Info Artifact
         if: always()
@@ -1442,7 +1616,7 @@ jobs:
           compression-level: 0
 
   finalize:
-    needs: [check, build_core, build_android, publish]
+    needs: [check, build_core, build_android, build_apple, publish]
     runs-on: ubuntu-latest
     if: always() && !cancelled()
     steps:
@@ -1517,7 +1691,8 @@ jobs:
           echo "| 任務 | 執行狀態 |" >> "$GITHUB_STEP_SUMMARY"
           echo "|------|------|" >> "$GITHUB_STEP_SUMMARY"
           echo "| 核心編譯 | ${{ needs.build_core.result }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| 客戶端編譯 | ${{ needs.build_android.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Android 客戶端 | ${{ needs.build_android.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Apple 客戶端 | ${{ needs.build_apple.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| 發佈打包 | ${{ needs.publish.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
@@ -1604,7 +1779,7 @@ jobs:
             });
 
   telegram_notify:
-    needs: [build_core, build_android, publish, finalize]
+    needs: [build_core, build_android, build_apple, publish, finalize]
     runs-on: ubuntu-latest
     if: always() && (github.event.inputs.enable_telegram == 'true' || github.event_name == 'schedule')
     steps:
@@ -1614,26 +1789,34 @@ jobs:
           TG_STATUS="success"
           declare -a STATUS_LINES
 
-          for job in build_core build_android publish; do
+          for job in build_core build_android build_apple publish; do
             RESULT=""
             if [ "$job" = "build_core" ]; then RESULT="${{ needs.build_core.result }}"
             elif [ "$job" = "build_android" ]; then RESULT="${{ needs.build_android.result }}"
+            elif [ "$job" = "build_apple" ]; then RESULT="${{ needs.build_apple.result }}"
             elif [ "$job" = "publish" ]; then RESULT="${{ needs.publish.result }}"
             fi
 
             case "$RESULT" in
               success) STATUS_LINES+=("✅ ${job}: success") ;;
-              failure) TG_STATUS="failed"; STATUS_LINES+=("❌ ${job}: failure") ;;
+              failure)
+                # build_apple 非阻塞，失敗只標記不影響整體 TG_STATUS
+                if [ "$job" = "build_apple" ]; then
+                  STATUS_LINES+=("⚠️ ${job}: failure (non-blocking)")
+                else
+                  TG_STATUS="failed"; STATUS_LINES+=("❌ ${job}: failure")
+                fi ;;
               skipped) STATUS_LINES+=("⏭️ ${job}: skipped") ;;
               *) STATUS_LINES+=("❓ ${job}: ${RESULT}") ;;
             esac
           done
 
           ALL_SKIPPED=true
-          for job in build_core build_android publish; do
+          for job in build_core build_android build_apple publish; do
             RESULT=""
             if [ "$job" = "build_core" ]; then RESULT="${{ needs.build_core.result }}"
             elif [ "$job" = "build_android" ]; then RESULT="${{ needs.build_android.result }}"
+            elif [ "$job" = "build_apple" ]; then RESULT="${{ needs.build_apple.result }}"
             elif [ "$job" = "publish" ]; then RESULT="${{ needs.publish.result }}"
             fi
             if [ "$RESULT" != "skipped" ]; then ALL_SKIPPED=false; break; fi
@@ -1873,7 +2056,7 @@ jobs:
           BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
 
   create_issue_on_failure:
-    needs: [build_core, build_android, publish, finalize, telegram_notify]
+    needs: [build_core, build_android, build_apple, publish, finalize, telegram_notify]
     if: failure() && (github.event_name == 'schedule' || github.event_name == 'push')
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 > 自動檢測並編譯 [reF1nd/sing-box](https://github.com/reF1nd/sing-box) 的 Stable 和 Testing 分支。
 
-## 📦 最新版本狀態 (2026-06-27 00:13 UTC+8)
+## 📦 最新版本狀態 (2026-06-27 01:16 UTC+8)
 
-- 🔄 強制構建 **[reF1nd_Stable](https://github.com/reF1nd/sing-box/tree/reF1nd-stable)** `vunknown` (2026-06-26) [reF1nd_Stable vunknown]
-- 🔄 強制構建 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** `vunknown` (2026-06-26) [reF1nd_Testing vunknown]
+- 🔄 強制構建 **[reF1nd_Stable](https://github.com/reF1nd/sing-box/tree/reF1nd-stable)** `vunknown` (2026-06-27) [reF1nd_Stable vunknown]
+- 🔄 強制構建 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** `vunknown` (2026-06-27) [reF1nd_Testing vunknown]
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 自動檢測並編譯 [reF1nd/sing-box](https://github.com/reF1nd/sing-box) 的 Stable 和 Testing 分支。
 
-## 📦 最新版本狀態 (2026-06-26 21:30 UTC+8)
+## 📦 最新版本狀態 (2026-06-27 00:13 UTC+8)
 
 - 🔄 強制構建 **[reF1nd_Stable](https://github.com/reF1nd/sing-box/tree/reF1nd-stable)** `vunknown` (2026-06-26) [reF1nd_Stable vunknown]
 - 🔄 強制構建 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** `vunknown` (2026-06-26) [reF1nd_Testing vunknown]

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 > 自動檢測並編譯 [reF1nd/sing-box](https://github.com/reF1nd/sing-box) 的 Stable 和 Testing 分支。
 
-## 📦 最新版本狀態 (2026-06-26 11:03 UTC+8)
+## 📦 最新版本狀態 (2026-06-26 14:12 UTC+8)
 
-- ✨ 更新 **[reF1nd_Stable](https://github.com/reF1nd/sing-box/tree/reF1nd-stable)** 至 `vd7f9dfab`，發佈於 2026-06-25 [reF1nd_Stable vd7f9dfab]
-- ✨ 更新 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** 至 `v1.14.0-alpha.35-reF1nd.1`，發佈於 2026-06-25 [reF1nd_Testing v1.14.0-alpha.35-reF1nd.1]
+- 🔄 強制構建 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** `vunknown` (2026-06-26) [reF1nd_Testing vunknown]
 
 ---
 
@@ -39,4 +38,4 @@ bash <(curl -sSL https://github.com/phpr-source/sing-box.json/releases/download/
 
 [🔗 前往 Releases 下載](https://github.com/phpr-source/sing-box.json/releases)
 
-![Build Status](https://img.shields.io/github/actions/workflow/status/phpr-source/sing-box.json/build-sing-box.yml?branch=main)
+![Build Status](https://img.shields.io/github/actions/workflow/status/phpr-source/sing-box.json/build-sing-box.yml?branch=feat-build-apple)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 自動檢測並編譯 [reF1nd/sing-box](https://github.com/reF1nd/sing-box) 的 Stable 和 Testing 分支。
 
-## 📦 最新版本狀態 (2026-06-27 01:16 UTC+8)
+## 📦 最新版本狀態 (2026-06-27 09:47 UTC+8)
 
 - 🔄 強制構建 **[reF1nd_Stable](https://github.com/reF1nd/sing-box/tree/reF1nd-stable)** `vunknown` (2026-06-27) [reF1nd_Stable vunknown]
 - 🔄 強制構建 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** `vunknown` (2026-06-27) [reF1nd_Testing vunknown]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 自動檢測並編譯 [reF1nd/sing-box](https://github.com/reF1nd/sing-box) 的 Stable 和 Testing 分支。
 
-## 📦 最新版本狀態 (2026-06-26 14:12 UTC+8)
+## 📦 最新版本狀態 (2026-06-26 14:59 UTC+8)
 
 - 🔄 強制構建 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** `vunknown` (2026-06-26) [reF1nd_Testing vunknown]
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 > 自動檢測並編譯 [reF1nd/sing-box](https://github.com/reF1nd/sing-box) 的 Stable 和 Testing 分支。
 
-## 📦 最新版本狀態 (2026-06-26 19:57 UTC+8)
+## 📦 最新版本狀態 (2026-06-26 20:52 UTC+8)
 
+- 🔄 強制構建 **[reF1nd_Stable](https://github.com/reF1nd/sing-box/tree/reF1nd-stable)** `vunknown` (2026-06-26) [reF1nd_Stable vunknown]
 - 🔄 強制構建 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** `vunknown` (2026-06-26) [reF1nd_Testing vunknown]
 
 ---

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 自動檢測並編譯 [reF1nd/sing-box](https://github.com/reF1nd/sing-box) 的 Stable 和 Testing 分支。
 
-## 📦 最新版本狀態 (2026-06-26 17:02 UTC+8)
+## 📦 最新版本狀態 (2026-06-26 17:25 UTC+8)
 
 - 🔄 強制構建 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** `vunknown` (2026-06-26) [reF1nd_Testing vunknown]
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 自動檢測並編譯 [reF1nd/sing-box](https://github.com/reF1nd/sing-box) 的 Stable 和 Testing 分支。
 
-## 📦 最新版本狀態 (2026-06-26 17:25 UTC+8)
+## 📦 最新版本狀態 (2026-06-26 18:21 UTC+8)
 
 - 🔄 強制構建 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** `vunknown` (2026-06-26) [reF1nd_Testing vunknown]
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 自動檢測並編譯 [reF1nd/sing-box](https://github.com/reF1nd/sing-box) 的 Stable 和 Testing 分支。
 
-## 📦 最新版本狀態 (2026-06-26 18:45 UTC+8)
+## 📦 最新版本狀態 (2026-06-26 19:13 UTC+8)
 
 - 🔄 強制構建 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** `vunknown` (2026-06-26) [reF1nd_Testing vunknown]
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 自動檢測並編譯 [reF1nd/sing-box](https://github.com/reF1nd/sing-box) 的 Stable 和 Testing 分支。
 
-## 📦 最新版本狀態 (2026-06-26 19:13 UTC+8)
+## 📦 最新版本狀態 (2026-06-26 19:57 UTC+8)
 
 - 🔄 強制構建 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** `vunknown` (2026-06-26) [reF1nd_Testing vunknown]
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 自動檢測並編譯 [reF1nd/sing-box](https://github.com/reF1nd/sing-box) 的 Stable 和 Testing 分支。
 
-## 📦 最新版本狀態 (2026-06-26 18:21 UTC+8)
+## 📦 最新版本狀態 (2026-06-26 18:45 UTC+8)
 
 - 🔄 強制構建 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** `vunknown` (2026-06-26) [reF1nd_Testing vunknown]
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 自動檢測並編譯 [reF1nd/sing-box](https://github.com/reF1nd/sing-box) 的 Stable 和 Testing 分支。
 
-## 📦 最新版本狀態 (2026-06-26 20:52 UTC+8)
+## 📦 最新版本狀態 (2026-06-26 21:30 UTC+8)
 
 - 🔄 強制構建 **[reF1nd_Stable](https://github.com/reF1nd/sing-box/tree/reF1nd-stable)** `vunknown` (2026-06-26) [reF1nd_Stable vunknown]
 - 🔄 強制構建 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** `vunknown` (2026-06-26) [reF1nd_Testing vunknown]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 自動檢測並編譯 [reF1nd/sing-box](https://github.com/reF1nd/sing-box) 的 Stable 和 Testing 分支。
 
-## 📦 最新版本狀態 (2026-06-26 14:59 UTC+8)
+## 📦 最新版本狀態 (2026-06-26 17:02 UTC+8)
 
 - 🔄 強制構建 **[reF1nd_Testing](https://github.com/reF1nd/sing-box/tree/reF1nd-testing)** `vunknown` (2026-06-26) [reF1nd_Testing vunknown]
 


### PR DESCRIPTION
## Summary

This PR fixes `build_apple`, adds SFM (macOS) build artifacts, and removes `continue-on-error: true`.

### Root cause fix
reF1nd's `experimental/libbox` has a two-directional API skew vs the pinned Apple client submodule:
- reF1nd-stable libbox = old API → needs pinned client 794eb1741f
- reF1nd-testing libbox = new API (WriteOutbounds, openShellSession, etc.) → needs latest upstream dev client

**Fix (commit a7e8873d):** detect libbox API era by grepping `WriteOutbounds` in `experimental/libbox/command_client.go`. Replace pinned client with latest upstream dev only when the core is on the new API; otherwise keep the pinned client.

### SFM (macOS) build
- New xcodebuild step for `SFM` scheme, ldid-signed with `SFM.entitlements`, packaged as `.zip`
- Universal `Libbox.xcframework` (ios+iossimulator+tvos+tvossimulator+macos) shared by both SFI and SFM
- Fix: `-skipPackagePluginValidation` for signed build (SwiftLintPlugin validation fails unsigned)

### Other changes
- Removed `continue-on-error: true` — future build_apple failures block the workflow
- Updated publish job to include `.zip` in release artifacts with per-type labeling

### Verification (run 28251444593, all passed)
| Job | Result |
|-----|--------|
| build_apple (Testing) | ✅ success |
| build_apple (Stable) | ✅ success |
| Artifact size | 132 MB (SFI .tipa + SFM .zip) |
| SFM binary | 277 MB `sing-box.app/Contents/MacOS/sing-box` |